### PR TITLE
Add Hedgedoc authentication

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -10,6 +10,7 @@ import simplifyPlugin from "@graphile-contrib/pg-simplify-inflector";
 import PgPubsub from "@graphile/pg-pubsub";
 import importCtfPlugin from "./plugins/importCtf";
 import createTasKPlugin from "./plugins/createTask";
+import hedgedocAuth from "./plugins/hedgedocAuth";
 import { settingsPlugin, settingsHook } from "./plugins/settings";
 
 dotenv.config();
@@ -36,9 +37,15 @@ const postgraphileOptions: PostGraphileOptions = {
     importCtfPlugin,
     createTasKPlugin,
     settingsPlugin,
+    hedgedocAuth
   ],
   enableQueryBatching: true,
   legacyRelations: "omit" as const,
+  async additionalGraphQLContextFromRequest(req, res) {
+    return {
+      setHeader: (name: string, value: string | number) => res.setHeader(name, value)
+    };
+  },
 };
 
 if (process.env.NODE_ENV == "development") {
@@ -66,5 +73,5 @@ app.use(
 );
 
 app.listen(3000, () => {
-	console.log("Listening on :3000");
+  console.log("Listening on :3000");
 });

--- a/api/src/plugins/hedgedocAuth.ts
+++ b/api/src/plugins/hedgedocAuth.ts
@@ -1,0 +1,136 @@
+import { makeWrapResolversPlugin, gql } from "graphile-utils";
+import axios from "axios";
+import savepointWrapper from "./savepointWrapper";
+import querystring from "querystring";
+
+class HedgedocAuth {
+	private static async baseUrl(): Promise<string | null> {
+		let cleanUrl: string =
+			process.env.CREATE_PAD_URL || "http://hedgedoc:3000/new";
+		cleanUrl = cleanUrl.slice(0, -4); //remove '/new' for clean url
+		return cleanUrl;
+	}
+
+	private static async authPad(
+		username: string,
+		password: string,
+		url: URL
+	): Promise<string> {
+		let domain: string;
+		//if domain does not end in '.[tld]', it will be rejected
+		//so we add '.local' manually
+		if (url.hostname.split(".").length == 1) {
+			domain = `${url.hostname}.local`;
+		} else {
+			domain = url.hostname;
+		}
+
+		const email = `${username}@${domain}`;
+
+		try {
+			const res = await axios.post(
+				url.toString(),
+				querystring.stringify({
+					email: email,
+					password: password,
+				}),
+				{
+					validateStatus: (status) => status === 302,
+					maxRedirects: 0,
+					timeout: 5000,
+					headers: {
+						"Content-Type": "application/x-www-form-urlencoded",
+					},
+				}
+			);
+			return res.headers["set-cookie"][0].replace("HttpOnly;", "");
+		} catch (e) {
+			console.error(e);
+			return "";
+		}
+	}
+
+	static async register(username: string, password: string): Promise<string> {
+		const authUrl = new URL(`${await this.baseUrl()}/register`);
+		return this.authPad(username, password, authUrl);
+	}
+
+	static async verifyLogin(cookie: string) {
+		const url = new URL(`${await this.baseUrl()}/me`);
+
+		try {
+			const res = await axios.get(url.toString(), {
+				validateStatus: (status) => status === 200,
+				maxRedirects: 0,
+				timeout: 5000,
+				headers: {
+					Cookie: cookie,
+				},
+			});
+
+			return res.data.status == "ok";
+		} catch (e) {
+			return false;
+		}
+	}
+
+	static async login(username: string, password: string): Promise<string> {
+		const authUrl = new URL(`${await this.baseUrl()}/login`);
+		const result = await this.authPad(username, password, authUrl);
+		const success = await this.verifyLogin(result);
+		if (!success) {
+			//create account for existing users that are not registered to Hedgedoc
+			await this.register(username, password);
+			return this.authPad(username, password, authUrl);
+		} else {
+			return result;
+		}
+	}
+}
+
+export default makeWrapResolversPlugin({
+	Mutation: {
+		login: {
+			async resolve(
+				resolve: any,
+				_source,
+				args,
+				context: any,
+				_resolveInfo
+			) {
+				const result = await resolve();
+				context.setHeader(
+					"set-cookie",
+					await HedgedocAuth.login(
+						args.input.login,
+						args.input.password
+					)
+				);
+				return result;
+			},
+		},
+		register: {
+			async resolve(
+				resolve: any,
+				_source,
+				args,
+				context: any,
+				_resolveInfo
+			) {
+				const result = await resolve();
+				await HedgedocAuth.register(
+					args.input.login,
+					args.input.password
+				);
+				context.setHeader(
+					"set-cookie",
+					await HedgedocAuth.login(
+						args.input.login,
+						args.input.password
+					)
+				);
+				return result;
+			},
+		},
+	},
+});

--- a/front/src/boot/CTFNote.js
+++ b/front/src/boot/CTFNote.js
@@ -91,6 +91,8 @@ class CTFNote {
   }
   logout() {
     localStorage.removeItem("JWT");
+    //cleanup Hedgedoc cookie
+    document.cookie = "connect.sid" + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
     this._me = null;
   }
 

--- a/front/src/pages/Auth.vue
+++ b/front/src/pages/Auth.vue
@@ -12,7 +12,8 @@
               v-model="username"
               label="Username"
               lazy-rules
-              :rules="[val => (val && val.length > 0) || 'Please type something']"
+              :rules="[val => (val && val.length > 0) || 'Please type something', val => val && val.indexOf('@') === -1 || 'Please dont use @']"
+              hint="Your username is visible to other members"
             />
             <q-input
               filled


### PR DESCRIPTION
When a new account is created, CTFNote now tries to register the user to Hedgedoc. After that, the user will be automatically authenticated to Hedgedoc when logging in. The slug and password of the user are used for registering.

The benefit of authenticating is that the cursor of the user shows the username and changes by users are shown by Hedgedoc.

No new URL is required, because the MD create url is used for building the URL.

Follow up of https://github.com/TFNS/CTFNote/pull/32