### PR TITLE
Add pre-build images through GHCR

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,46 @@
+name: "Build and publish Docker images to GHCR"
+
+on:
+    workflow_call:
+    push:
+        branches:
+            - "main"
+
+jobs:
+    build_and_publish:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v2
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v2
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v2
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.repository_owner }}
+                  password: ${{ github.token }}
+            - name: PrepareReg Names
+              run: |
+                  echo IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+                  echo IMAGE_TAG=$(echo ${{ github.ref }} | tr '[:upper:]' '[:lower:]' | awk '{split($0,a,"/"); print a[3]}') >> $GITHUB_ENV
+            - name: Build and push
+              uses: docker/build-push-action@v4
+              with:
+                  context: ./front
+                  push: true
+                  tags: ghcr.io/${{env.IMAGE_REPOSITORY}}/front:latest
+            - name: Build and push
+              uses: docker/build-push-action@v4
+              with:
+                  context: ./api
+                  push: true
+                  tags: ghcr.io/${{env.IMAGE_REPOSITORY}}/api:latest
+            - name: Build and push
+              uses: docker/build-push-action@v4
+              with:
+                  context: ./db
+                  push: true
+                  tags: ghcr.io/${{env.IMAGE_REPOSITORY}}/db:latest

--- a/README.md
+++ b/README.md
@@ -12,12 +12,30 @@ CTFNote is a collaborative tool aiming to help CTF teams to organise their work.
 
 Before starting, make sure to fill in the information in the `.env` file.
 
-Then you can start it with `docker-compose`. The default
+### Pre-build images
+
+Building CTFNote requires at least 3 GB of RAM. If you want to host CTFNote
+on a server with less than 3 GB of RAM, you can use the pre-build images
+from the Github Container Registry.
+
+Make sure to [authenticate Docker to GHCR](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic).
+
+Download `docker-compose.yml` and `docker-compose.prebuild.yml` for example through cloning the repository and run:
+
+```shell
+$ docker compose -f docker-compose.prebuild.yml up -d
+```
+
+### Self-build images
+
+You can build and start CTFNote with `docker compose`. The default
 configuration makes it super easy to start a new instance!
 
 ```shell
-$ docker-compose up -d
+$ docker compose up -d
 ```
+
+### Accessing the instance
 
 The instance will spawn a web server on port `127.0.0.1:8080`. The first account created will
 have administrative privileges.

--- a/docker-compose.prebuild.yml
+++ b/docker-compose.prebuild.yml
@@ -1,0 +1,30 @@
+version: "3.7"
+services:
+    api:
+        image: ghcr.io/jj-8/ctfnote/api:latest
+        extends:
+            file: docker-compose.yml
+            service: api
+    db:
+        image: ghcr.io/jj-8/ctfnote/db:latest
+        extends:
+            file: docker-compose.yml
+            service: db
+    front:
+        image: ghcr.io/jj-8/ctfnote/front:latest
+        extends:
+            file: docker-compose.yml
+            service: front
+    hedgedoc:
+        extends:
+            file: docker-compose.yml
+            service: hedgedoc
+volumes:
+    ctfnote-db:
+        name: ctfnote
+    ctfnote-uploads:
+        name: ctfnote-uploads
+    pad-uploads:
+        name: pad-uploads
+networks:
+    ctfnote:


### PR DESCRIPTION
Docker images of the front, api and db will be automatically build through Github workflows and pushed to the Github Container Registry (GHCR) when a commit is made to the main branch (or when manually triggered).

This makes it possible to install CTFNote on a VPS of 2 GB of RAM since you don't need to build the container anymore (which requires quite a lot of RAM). Building the container yourself is still possible and the default setup for docker compose.

The README is updated with this change.
Futhermore, the REAMDE now points to `docker compose` instead of the deprecated `docker-compose`.