### PR TITLE
Update CTF end date if before start date

### DIFF
--- a/api/migrations/41-illegal-dates.sql
+++ b/api/migrations/41-illegal-dates.sql
@@ -1,1 +1,2 @@
+UPDATE ctfnote.ctf SET end_time = start_time WHERE end_time < start_time;
 ALTER TABLE ctfnote.ctf ADD CONSTRAINT no_illegal_end_time CHECK (end_time >= start_time);


### PR DESCRIPTION
Without this fix, CTFNote will crash in the unlikely event that an invalid CTF exists:
```
/app/node_modules/postgres-migrations/dist/migrate.js:100
            const error = new Error(`Migration failed. Reason: ${e.message}`);
                          ^

Error: Migration failed. Reason: An error occurred running 'illegal-dates'. Rolled back this migration. No further migrations were run. Reason: check constraint "no_illegal_end_time" of relation "ctf" is violated by some row
    at /app/node_modules/postgres-migrations/dist/migrate.js:100:27
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async /app/node_modules/postgres-migrations/dist/with-lock.js:25:28
    at async /app/node_modules/postgres-migrations/dist/with-connection.js:16:28 {
  cause: Error: An error occurred running 'illegal-dates'. Rolled back this migration. No further migrations were run. Reason: check constraint "no_illegal_end_time" of relation "ctf" is violated by some row
      at /app/node_modules/postgres-migrations/dist/run-migration.js:36:15
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at async /app/node_modules/postgres-migrations/dist/migrate.js:91:32
      at async /app/node_modules/postgres-migrations/dist/with-lock.js:25:28
      at async /app/node_modules/postgres-migrations/dist/with-connection.js:16:28
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```