### PR TITLE
Add justCTF parser

### DIFF
--- a/front/src/ctfnote/parsers/index.ts
+++ b/front/src/ctfnote/parsers/index.ts
@@ -3,6 +3,7 @@ import ECSCParser from './ecsc';
 import RawParser from './raw';
 import HTBParser from './htb';
 import PicoParser from './pico';
+import justCTFParser from './justctf';
 
 export type ParsedTask = {
   title: string;
@@ -18,4 +19,11 @@ export type Parser = {
   parse(s: string): ParsedTask[];
 };
 
-export default [RawParser, CTFDParser, ECSCParser, HTBParser, PicoParser];
+export default [
+  RawParser,
+  CTFDParser,
+  ECSCParser,
+  HTBParser,
+  PicoParser,
+  justCTFParser,
+];

--- a/front/src/ctfnote/parsers/justctf.ts
+++ b/front/src/ctfnote/parsers/justctf.ts
@@ -28,15 +28,10 @@ const justCTFParser: Parser = {
       if (!challenge.description || !challenge.name) {
         continue;
       }
-      let category = 'unknown';
-
-      // as soon as CTFNote supports tags, we can rewrite this
-      // and maybe add the difficulty as a tag as well
-      if (challenge.categories.length > 0) category = challenge.categories[0];
 
       tasks.push({
         title: challenge.name,
-        category: category,
+        tags: challenge.categories,
         description: challenge.description,
       });
     }

--- a/front/src/ctfnote/parsers/justctf.ts
+++ b/front/src/ctfnote/parsers/justctf.ts
@@ -1,0 +1,70 @@
+import { ParsedTask, Parser } from '.';
+import { parseJson, parseJsonStrict } from '../utils';
+
+const justCTFParser: Parser = {
+  name: 'justCTF parser',
+  hint: 'paste /api/v1/tasks',
+
+  parse(s: string): ParsedTask[] {
+    const tasks = [];
+    const data = parseJsonStrict<
+      [
+        {
+          id: number;
+          name: string;
+          categories: [string];
+          difficult: string;
+          description: string;
+          points: number;
+          solvers: number;
+        }
+      ]
+    >(s);
+    if (data == null) {
+      return [];
+    }
+
+    for (const challenge of data) {
+      if (!challenge.description || !challenge.name) {
+        continue;
+      }
+      let category = 'unknown';
+
+      // as soon as CTFNote supports tags, we can rewrite this
+      // and maybe add the difficulty as a tag as well
+      if (challenge.categories.length > 0) category = challenge.categories[0];
+
+      tasks.push({
+        title: challenge.name,
+        category: category,
+        description: challenge.description,
+      });
+    }
+    return tasks;
+  },
+  isValid(s) {
+    const data = parseJson<
+      [
+        {
+          id: number;
+          name: string;
+          categories: [string];
+          difficult: string;
+          description: string;
+          points: number;
+          solvers: number;
+        }
+      ]
+    >(s);
+    return (
+      data != null &&
+      data?.length > 0 &&
+      data[0].id != null &&
+      data[0].name != null &&
+      Array.isArray(data[0].categories) &&
+      data[0].points != null
+    );
+  },
+};
+
+export default justCTFParser;

--- a/front/src/ctfnote/parsers/pico.ts
+++ b/front/src/ctfnote/parsers/pico.ts
@@ -22,8 +22,16 @@ const PicoParser: Parser = {
     return tasks;
   },
   isValid(s) {
-    const data = parseJson<{ results?: unknown }>(s);
-    return Array.isArray(data?.results);
+    const data = parseJson<{
+      results: Array<{ name: string; category: { name: string } }>;
+    }>(s);
+    return (
+      data?.results != null &&
+      Array.isArray(data?.results) &&
+      data?.results.length > 0 &&
+      data?.results[0].name != null &&
+      data?.results[0].category.name != null
+    );
   },
 };
 


### PR DESCRIPTION
This parser is based on the 2022/2023 edition of justCTF. I have manually tested that the detection of parser still works for every other parser.

The parser of picoCTF has been made more stricter to prevent future issues.

Parser has been updated to take tags into account.