### PR TITLE
Add session secret environment variable

### DIFF
--- a/.env
+++ b/.env
@@ -15,3 +15,7 @@
 # DISCORD_BOT_TOKEN=secret_token
 # DISCORD_SERVER_ID=server_id
 # DISCORD_VOICE_CHANNELS=3
+
+# Can be generated with e.g. pwgen -s 64 1
+# Please provide a string of length 64+ characters
+# SESSION_SECRET=

--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -9,6 +9,7 @@ type DeepReadOnly<T> = {
 
 export type CTFNoteConfig = DeepReadOnly<{
   env: string;
+  sessionSecret: string;
   db: {
     database: string;
     admin: {
@@ -54,6 +55,7 @@ function getEnvInt(name: string): number {
 
 const config: CTFNoteConfig = {
   env: getEnv("NODE_ENV"),
+  sessionSecret: getEnv("SESSION_SECRET", ""),
   db: {
     database: getEnv("DB_DATABASE"),
     user: {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -30,7 +30,15 @@ function getDbUrl(role: "user" | "admin") {
 }
 
 function createOptions() {
-  const secret = crypto.randomBytes(32).toString("hex");
+  let secret: string;
+  if (config.sessionSecret.length < 64) {
+    console.info(
+      "Using random session secret since SESSION_SECRET is too short. All users will be logged out."
+    );
+    secret = crypto.randomBytes(32).toString("hex");
+  } else {
+    secret = config.sessionSecret;
+  }
 
   const postgraphileOptions: PostGraphileOptions = {
     pluginHook: makePluginHook([PgPubsub, OperationHook]),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-bot_token}
       DISCORD_SERVER_ID: ${DISCORD_SERVER_ID:-server_id}
       DISCORD_VOICE_CHANNELS: ${DISCORD_VOICE_CHANNELS:-3}
+      SESSION_SECRET: ${SESSION_SECRET:-}
     depends_on:
       - db
     volumes:


### PR DESCRIPTION
The variable cannot be set for Hedgedoc since providing a default value does work there. This can be a security risk.