### PR TITLE
Improve mention resolution

### DIFF
--- a/api/src/discord/utils/messages.ts
+++ b/api/src/discord/utils/messages.ts
@@ -197,11 +197,12 @@ export async function convertMessagesToPadFormat(messages: Message<boolean>[]) {
             const discordChannel = message.guild?.channels.cache.get(id);
 
             if (discordUser != null) {
+              const nickname = discordUser.nickname != null ? ` (${discordUser.nickname})` : ``;
               content = content.replace(
                 mention,
                 discordUser.user.discriminator != "0"
-                  ? `@${discordUser.user.username}#${discordUser.user.discriminator}`
-                  : `@${discordUser.user.username}`
+                  ? `@${discordUser.user.username}#${discordUser.user.discriminator}${nickname}`
+                  : `@${discordUser.user.username}${nickname}`
               );
             }
 

--- a/api/src/discord/utils/messages.ts
+++ b/api/src/discord/utils/messages.ts
@@ -188,20 +188,29 @@ export async function convertMessagesToPadFormat(messages: Message<boolean>[]) {
         if (content.startsWith("```")) content = "\n" + content;
         if (content.startsWith("> ")) content = content + "\n"; // need an extra line break for quotes
 
-        // resolve mentions to usernames
+        // resolve mentions to usernames or channelnames
         const mentions = content.match(/<(?:[^\d>]+|:[A-Za-z0-9]+:)\w+>/g);
         if (mentions != null) {
-          mentions.forEach((user) => {
-            const id = user.replace(/\D/g, "");
+          mentions.forEach((mention) => {
+            const id = mention.replace(/\D/g, "");
             const discordUser = message.guild?.members.cache.get(id);
-            if (discordUser == null) return;
+            const discordChannel = message.guild?.channels.cache.get(id);
 
-            content = content.replace(
-              user,
-              discordUser.user.discriminator != "0"
-                ? `@${discordUser.user.username}#${discordUser.user.discriminator}`
-                : `@${discordUser.user.username}`
-            );
+            if (discordUser != null) {
+              content = content.replace(
+                mention,
+                discordUser.user.discriminator != "0"
+                  ? `@${discordUser.user.username}#${discordUser.user.discriminator}`
+                  : `@${discordUser.user.username}`
+              );
+            }
+
+            if (discordChannel != null) {
+              content = content.replace(
+                mention,
+                `#${discordChannel.name}`
+              );
+            }
           });
         }
 


### PR DESCRIPTION
This adds server nicknames to any mentions of users and replaces channel references with the channel names.

Couple of things that might need more consideration:
 - With channel references it is not possible to see if they actually existed at the archival time.
 - Some references could actually be Markdown references, but they are not made into those.
 - If a user has a Discord server nick and a different name in CTFNote, there will be two names in parentheses behind the mention (first the Discord nick, then the CTFNote name).