### PR TITLE
Add `/delete` to delete Discord CTF integration

### DIFF
--- a/api/src/discord/commands.ts
+++ b/api/src/discord/commands.ts
@@ -4,6 +4,7 @@ import { ArchiveCtf } from "./commands/archiveCtf";
 import { SolveTask } from "./commands/solveTask";
 import { LinkUser } from "./commands/linkUser";
 import { StartWorking, StopWorking } from "./commands/workingOn";
+import { DeleteCtf } from "./commands/deleteCtf";
 
 export const Commands: Command[] = [
   ArchiveCtf,
@@ -12,4 +13,5 @@ export const Commands: Command[] = [
   LinkUser,
   StartWorking,
   StopWorking,
+  DeleteCtf,
 ];

--- a/api/src/discord/utils/messages.ts
+++ b/api/src/discord/utils/messages.ts
@@ -15,6 +15,8 @@ import { CTF, getCtfFromDatabase } from "../database/ctfs";
 import { getTaskChannel } from "./channels";
 import { createPad } from "../../plugins/createTask";
 
+export const discordArchiveTaskName = "Discord archive";
+
 export async function sendMessageToChannel(
   channel: TextChannel,
   message: string | null | undefined,
@@ -243,7 +245,7 @@ export async function createPadWithoutLimit(
     if (currentPadLength + messageLength > MAX_PAD_LENGTH) {
       // Create a new pad
       const padUrl = await createPad(
-        `${ctfTitle} Discord archive (${padIndex})`,
+        `${ctfTitle} ${discordArchiveTaskName} (${padIndex})`,
         currentPadMessages.join("\n")
       );
 
@@ -263,7 +265,7 @@ export async function createPadWithoutLimit(
   if (pads.length > 0) {
     // Create the final pad for the remaining messages
     const padUrl = await createPad(
-      `${ctfTitle} Discord archive (${padIndex})`,
+      `${ctfTitle} ${discordArchiveTaskName} (${padIndex})`,
       currentPadMessages.join("\n")
     );
     pads.push(padUrl);
@@ -276,7 +278,10 @@ export async function createPadWithoutLimit(
     firstPadContent = currentPadMessages.join("\n");
   }
 
-  return await createPad(`${ctfTitle} Discord archive`, firstPadContent);
+  return await createPad(
+    `${ctfTitle} ${discordArchiveTaskName}`,
+    firstPadContent
+  );
 }
 
 export const topicDelimiter = " /-/";


### PR DESCRIPTION
It is mandatory to create an archive first before deleting the CTF. This prevents data loss and the resulting task can always be deleted manually. The archive command will now not delete the channels anymore.

Finishing of the commands will now be reflected in the bot reply.