### PR TITLE
Discord archive: image handling and recursive pad export

### DIFF
--- a/api/src/discord/utils/messages.ts
+++ b/api/src/discord/utils/messages.ts
@@ -183,7 +183,11 @@ export async function convertMessagesToPadFormat(messages: Message<boolean>[]) {
 
         if (message.attachments.size > 0) {
           message.attachments.forEach((attachment) => {
-            message.content += attachment.url + " ";
+            if (attachment.contentType?.startsWith("image/")) {
+              message.content += ` ![${attachment.name}](${attachment.url}) `;
+            } else {
+              message.content += ` ${attachment.url} `;
+            }
           });
         }
 

--- a/front/src/components/Dialogs/TaskExportDialog.vue
+++ b/front/src/components/Dialogs/TaskExportDialog.vue
@@ -87,6 +87,26 @@ export default defineComponent({
         }
         markdown = withTitle + '\n' + markdown;
       }
+
+      // fetch subtasks recursively
+      const subTasks = [
+        ...markdown.matchAll(
+          new RegExp(
+            `(https?://${window.location.host}(/pad/[a-zA-Z0-9_-]*))`,
+            'g'
+          )
+        ),
+      ];
+
+      for (const subTask of subTasks) {
+        const subTaskMarkdown = await this.downloadTaskMarkdown({
+          ...task,
+          padUrl: subTask[1],
+        });
+
+        markdown += `\n\n---\nContent of ${subTask[0]}\n\n${subTaskMarkdown}`;
+      }
+
       return markdown;
     },
 


### PR DESCRIPTION
Images will now be properly rendered by Hedgedoc when exporting the Discord archive.

When the note content is too big, it will be split in multiple pads.
But these pads won't be visible in the export.
This is now fixed by recursively fetch all tasks by matching the pad url.