### PR TITLE
Remove GHCR authentication notice in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Building CTFNote requires at least 3 GB of RAM. If you want to host CTFNote
 on a server with less than 3 GB of RAM, you can use the pre-build images
 from the GitHub Container Registry.
 
-Make sure to [authenticate Docker to GHCR](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic).
-
 Download `docker-compose.yml` and `docker-compose.prebuild.yml` for example through cloning the repository and run:
 
 ```shell


### PR DESCRIPTION
Copy of https://github.com/JJ-8/CTFNote/commit/8efa9bafdfd09e27cecd69d758b1faaa4215d730 but this one is upstream included in https://github.com/TFNS/CTFNote/pull/217.