### PR TITLE
Extend HTB parser categories

### DIFF
--- a/front/src/ctfnote/parsers/htb.ts
+++ b/front/src/ctfnote/parsers/htb.ts
@@ -24,6 +24,9 @@ const challengeCategories: { [index: number]: string } = {
   20: 'Cloud',
   21: 'Scada',
   23: 'ML',
+  25: 'TTX',
+  26: 'Trivia',
+  30: 'Sherlocks',
 };
 
 const HTBParser: Parser = {


### PR DESCRIPTION
The public API was extended with more categories, so we have to include them here too.

Public API can be found at https://ctf.hackthebox.com/api/public/challengeCategories