### PR TITLE
API: honour DB_HOST and DB_PORT

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -29,6 +29,8 @@ RUN yarn run build
 FROM node@${NODE_DIGEST} as clean
 # Import our shared args
 ARG NODE_ENV
+ARG DB_HOST
+ARG DB_PORT
 
 # Copy over selectively just the tings we need, try and avoid the rest
 COPY --from=builder /app/package.json /app/yarn.lock /app/.yarnrc.yml /app/start.sh /app/
@@ -58,4 +60,4 @@ RUN chown node /app/uploads
 ENV GRAPHILE_TURBO=1
 ENV NODE_ENV=$NODE_ENV
 USER node
-CMD ./start.sh db 5432 yarn start
+CMD ./start.sh ${DB_HOST} ${DB_PORT} yarn start


### PR DESCRIPTION
API needs to wait for the database to be up before starting.

We do not know how long it takes: just because the container is started doesn't
mean that Postgres is ready. The workaround is to use a small script (start.sh)
that waits until a connection to the database can be done before passing the
execution to yarn.

The Dockerfile contains hardcoded values for the database's hostname and ports,
but there is no guarantee that these values are always the same. This is
especially true when trying to deploy CTFNote with a previously-existing
database.

This commit removes the hardcoded values and replaces them with DB_HOST/DB_PORT.

Upstream commit: https://github.com/TFNS/CTFNote/pull/235/commits/9606303fe489f8e62451807f47d6f8b2ee5ba18e
Upstream PR: https://github.com/TFNS/CTFNote/pull/235