### PR TITLE
Serve hotkeys-iframe.js from a path from Hedgedoc to circumvent CSP

### DIFF
--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -47,6 +47,12 @@ server {
         add_header Pragma "no-cache";
     }
 
+    # Due to the CSP of Hedgedoc, we need to serve the hotkeys-iframe.js file from here to allow execution
+    location /pad/js/hotkeys-iframe.js {
+        root /usr/share/nginx/html;
+        try_files $uri /hotkeys-iframe.js =404;
+    }
+
     location /pad/ {
         proxy_pass   http://hedgedoc:3000/;
         proxy_http_version 1.1;

--- a/front/src/pages/Task.vue
+++ b/front/src/pages/Task.vue
@@ -35,7 +35,7 @@ export default defineComponent({
         // inject hotkey script with some CTFNote code to catch hotkey for search dialog
         // and communicate that with the parent window
         const hotkeyScript = taskFrame.document.createElement('script');
-        hotkeyScript.src = '/hotkeys-iframe.js';
+        hotkeyScript.src = '/pad/js/hotkeys-iframe.js'; // this won't exist in development but will in production
         taskFrame.document.body.appendChild(hotkeyScript);
       });
     });


### PR DESCRIPTION
The Hedgedoc CSP is a good thing to have enabled.
But it breaks the JS injection done by CTFNote.
So now we just lie to the frontend that the file is hosted by Hedgedoc while it actually is hosted by CTFNote.

This should circumvent the CSP and allow script execution inside the iframe, even when the CSP is enabled.