### PR TITLE
Hide search dialog when pressing esc

### DIFF
--- a/front/src/components/Dialogs/SearchDialog.vue
+++ b/front/src/components/Dialogs/SearchDialog.vue
@@ -99,10 +99,12 @@ export default defineComponent({
 
     const previousShortcut = 'command+p, ctrl+p, up';
     const nextShortcut = 'command+n, ctrl+n, down';
+    const cancelShortcut = 'esc';
 
     onUnmounted(() => {
       hotkeys.unbind(previousShortcut);
       hotkeys.unbind(nextShortcut);
+      hotkeys.unbind(cancelShortcut);
     });
 
     onMounted(() => {
@@ -122,6 +124,12 @@ export default defineComponent({
         event.preventDefault();
         selectedItemIndex.value += 1;
         updateSelectedIndex();
+      });
+
+      hotkeys(cancelShortcut, (event) => {
+        event.stopImmediatePropagation();
+        event.preventDefault();
+        if (dialogRef) dialogRef.value?.hide();
       });
     });
 


### PR DESCRIPTION
In the old implementation you can only dismiss the search dialog by stop focussing it and then pressing esc or clicking outside the dialog area. This is not keyboard friendly so we introduce a new shortcut that hides the search dialog by just pressing the esc-button.